### PR TITLE
Removed await from page.click() to prevent race condition with waitForNavigation

### DIFF
--- a/crawler.js
+++ b/crawler.js
@@ -11,7 +11,7 @@ const login = async (browser, config) => {
 
   await page.type(selectors.login.username, credentials.username);
   await page.type(selectors.login.password, credentials.password);
-  await page.click(selectors.login.submit);
+  page.click(selectors.login.submit);
   await page.waitForNavigation();
 
   return page;

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const main = async () => {
   }
 
   await browser.close();
-  console.table(statuses);
+  console.log(statuses);
 }
 
 main();


### PR DESCRIPTION
Hey Umang! Thank you very much for this script. I saw your comment on an r/india thread and tried out your script. I have applied to many universities and this is huge time saver.
I do not know node.js but definitely wanted to try out this script. I found that after login, the page did not close properly and gave the error _Error: Navigation Timeout Exceeded: 30000ms exceeded_.
I found this related issue: https://github.com/GoogleChrome/puppeteer/issues/1412 where a reply suggested to remove await from page.click() to prevent a race condition between this and page.waitForNavigation(). This worked for me and I hope you maintain this repository as it would be helpful to many. 

PS - Even though I don't know node.js, I am interested in helping out in any way I can such as maybe including CSS selectors for university portals so that the usage becomes easier for people with non-tech backgrounds as well.  

Cheers!